### PR TITLE
Change README to account for username change

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,4 @@ Settings are located in ``installerSettings.json`` file
 
 ## ✍️ Authors <a name = "authors"></a>
 
-- [@retart1337](https://github.com/retart1337) - Main author
+- [@SPRAVEDLIVO](https://github.com/SPRAVEDLIVO) - Main author


### PR DESCRIPTION
Since SPRAVEDLIVO changed his username, the author section on the README now goes nowhere. This is fixed in my PR.